### PR TITLE
Downgrade golangci-lint to 1.23.8

### DIFF
--- a/scripts/go.mod
+++ b/scripts/go.mod
@@ -2,4 +2,8 @@ module github.com/dgrisonnet/client-go-playground/scripts
 
 go 1.14
 
-require github.com/golangci/golangci-lint v1.24.0
+require (
+	github.com/golangci/golangci-lint v1.23.8
+	github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa // indirect
+	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
+)

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -91,8 +91,8 @@ github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee h1:J2XAy40+7yz70u
 github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee/go.mod h1:ozx7R9SIwqmqf5pRP90DhR2Oay2UIjGuKheCBCNwAYU=
 github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a h1:iR3fYXUjHCR97qWS8ch1y9zPNsgXThGwjKPrYfqMPks=
 github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
-github.com/golangci/golangci-lint v1.24.0 h1:OcmSTTMPqI/VT4GvN1fKuE9NX15dDXIwolO0l08334U=
-github.com/golangci/golangci-lint v1.24.0/go.mod h1:yIqiAZ2SSQqg+1JeFlAdvEWjGVz4uu5jr4lrciqA1gE=
+github.com/golangci/golangci-lint v1.23.8 h1:NlD+Ld2TKH8qVmADy4iEvPxVmXaqPIeQu3d1cGQP4jc=
+github.com/golangci/golangci-lint v1.23.8/go.mod h1:g/38bxfhp4rI7zeWSxcdIeHTQGS58TCak8FYcyCmavQ=
 github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc h1:gLLhTLMk2/SutryVJ6D4VZCU3CUqr8YloG7FPIBWFpI=
 github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc/go.mod h1:e5tpTHCfVze+7EpLEozzMB3eafxo2KT5veNg1k6byQU=
 github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 h1:MfyDlzVjl1hoaPzPD4Gpb/QgoRfSBR0jdhwGyAWwMSA=
@@ -248,6 +248,7 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e h1:RumXZ56IrCj4CL+g1b9OL/oH0QnsF976bC8xQFYUD5Q=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tommy-muehle/go-mnd v1.1.1/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa h1:RC4maTWLKKwb7p1cnoygsbKIgNlJqSYBeAFON3Ar8As=
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -324,6 +325,7 @@ golang.org/x/tools v0.0.0-20190311215038-5c2858a9cfe5/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190322203728-c1a832b0ad89/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190521203540-521d6ed310dd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190719005602-e377ae9d6386/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190910044552-dd2b5c81c578/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -361,6 +363,7 @@ gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed h1:WX1yoOaKQfddO/mLzdV4wptyWgoH/6hwLs7QHTixo0I=

--- a/scripts/vendor/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go
+++ b/scripts/vendor/github.com/golangci/golangci-lint/pkg/golinters/goanalysis/runner.go
@@ -478,49 +478,6 @@ func (e *IllTypedError) Error() string {
 	return fmt.Sprintf("errors in package: %v", e.Pkg.Errors)
 }
 
-type FailedPrerequisitesError struct {
-	errors map[string][]string
-}
-
-func (f FailedPrerequisitesError) NotEmpty() bool {
-	return len(f.errors) > 0
-}
-
-func (f *FailedPrerequisitesError) Consume(name string, err error) {
-	if f.errors == nil {
-		f.errors = map[string][]string{}
-	}
-	k := fmt.Sprintf("%v", err)
-	f.errors[k] = append(f.errors[k], name)
-}
-
-type groupedPrerequisiteErr struct {
-	names []string
-	err   string
-}
-
-func (g groupedPrerequisiteErr) String() string {
-	if len(g.names) == 1 {
-		return fmt.Sprintf("%s: %s", g.names[0], g.err)
-	}
-	return fmt.Sprintf("(%s): %s", strings.Join(g.names, ", "), g.err)
-}
-
-func (f FailedPrerequisitesError) Error() string {
-	var errs []string
-	for err := range f.errors {
-		errs = append(errs, err)
-	}
-	var groups []groupedPrerequisiteErr
-	for _, err := range errs {
-		groups = append(groups, groupedPrerequisiteErr{
-			err:   err,
-			names: f.errors[err],
-		})
-	}
-	return fmt.Sprintf("failed prerequisites: %s", groups)
-}
-
 func (act *action) analyzeSafe() {
 	defer func() {
 		if p := recover(); p != nil {
@@ -544,16 +501,16 @@ func (act *action) analyze() {
 		analyzeDebugf("go/analysis: %s: %s: analyzed package %q in %s", act.r.prefix, act.a.Name, act.pkg.Name, time.Since(now))
 	}(time.Now())
 
-	// Report an error if any dependency failures.
-	var depErr FailedPrerequisitesError
+	// Report an error if any dependency failed.
+	var failed []string
 	for _, dep := range act.deps {
-		if dep.err == nil {
-			continue
+		if dep.err != nil {
+			failed = append(failed, dep.String())
 		}
-		depErr.Consume(dep.String(), dep.err)
 	}
-	if depErr.NotEmpty() {
-		act.err = depErr
+	if failed != nil {
+		sort.Strings(failed)
+		act.err = fmt.Errorf("failed prerequisites: %s", strings.Join(failed, ", "))
 		return
 	}
 

--- a/scripts/vendor/github.com/golangci/golangci-lint/pkg/golinters/govet.go
+++ b/scripts/vendor/github.com/golangci/golangci-lint/pkg/golinters/govet.go
@@ -101,11 +101,6 @@ var (
 
 func isAnalyzerEnabled(name string, cfg *config.GovetSettings, defaultAnalyzers []*analysis.Analyzer) bool {
 	if cfg.EnableAll {
-		for _, n := range cfg.Disable {
-			if n == name {
-				return false
-			}
-		}
 		return true
 	}
 	// Raw for loops should be OK on small slice lengths.

--- a/scripts/vendor/github.com/golangci/golangci-lint/pkg/result/processors/fixer.go
+++ b/scripts/vendor/github.com/golangci/golangci-lint/pkg/result/processors/fixer.go
@@ -218,7 +218,7 @@ func (f Fixer) writeFixedFile(origFileLines [][]byte, issues []result.Issue, tmp
 		}
 
 		origFileLineNumber := i + 1
-		if nextIssue == nil || origFileLineNumber != nextIssue.GetLineRange().From {
+		if nextIssue == nil || origFileLineNumber != nextIssue.Line() {
 			outLine = string(origFileLines[i])
 		} else {
 			nextIssueIndex++

--- a/scripts/vendor/modules.txt
+++ b/scripts/vendor/modules.txt
@@ -65,7 +65,7 @@ github.com/golangci/gocyclo/pkg/gocyclo
 # github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a
 github.com/golangci/gofmt/gofmt
 github.com/golangci/gofmt/goimports
-# github.com/golangci/golangci-lint v1.24.0
+# github.com/golangci/golangci-lint v1.23.8
 ## explicit
 github.com/golangci/golangci-lint/cmd/golangci-lint
 github.com/golangci/golangci-lint/internal/cache
@@ -187,6 +187,7 @@ github.com/subosito/gotenv
 # github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e
 github.com/timakin/bodyclose/passes/bodyclose
 # github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa
+## explicit
 github.com/tommy-muehle/go-mnd
 github.com/tommy-muehle/go-mnd/checks
 github.com/tommy-muehle/go-mnd/config
@@ -264,6 +265,7 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.2.7
 gopkg.in/yaml.v2
 # honnef.co/go/tools v0.0.1-2020.1.3
+## explicit
 honnef.co/go/tools/arg
 honnef.co/go/tools/code
 honnef.co/go/tools/config


### PR DESCRIPTION
Downgrading because 1.24.0 and 1.25.0 have OOM ongoing issues.