### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  timeout: 2m
+
 linters:
   enable:
     - megacheck


### PR DESCRIPTION
As the project is growing and has more and more dependencies, golangci
needs more time to load the source and the external libraries.