### PR TITLE
internal: add EventTime to timestamp filtering

### DIFF
--- a/internal/collector/event.go
+++ b/internal/collector/event.go
@@ -69,7 +69,6 @@ func (collector *EventCollector) Run(stopCh <-chan struct{}) {
 			ev := obj.(*v1.Event)
 			// Count only Events created after the exporter starts running.
 			if beforeLatestEvent(startRunning, ev) {
-				// FIXME: take into account the event count.
 				collector.increaseEventsTotal(ev, 1)
 			}
 		},

--- a/internal/collector/event.go
+++ b/internal/collector/event.go
@@ -68,7 +68,7 @@ func (collector *EventCollector) Run(stopCh <-chan struct{}) {
 		AddFunc: func(obj interface{}) {
 			ev := obj.(*v1.Event)
 			// Count only Events created after the exporter starts running.
-			if beforeLastEvent(startRunning, ev) {
+			if beforeLatestEvent(startRunning, ev) {
 				// FIXME: take into account the event count.
 				collector.increaseEventsTotal(ev, 1)
 			}
@@ -77,7 +77,7 @@ func (collector *EventCollector) Run(stopCh <-chan struct{}) {
 			oldEv := oldObj.(*v1.Event)
 			newEv := newObj.(*v1.Event)
 			// Count only Events updated after the exporter starts running.
-			if beforeLastEvent(startRunning, newEv) {
+			if beforeLatestEvent(startRunning, newEv) {
 				nbNew := updatedEventNb(oldEv, newEv)
 				collector.increaseEventsTotal(newEv, float64(nbNew))
 			}
@@ -95,12 +95,25 @@ func (collector *EventCollector) increaseEventsTotal(event *v1.Event, nbNew floa
 	}).Add(nbNew)
 }
 
-func beforeLastEvent(t time.Time, ev *v1.Event) bool {
-	if ev.Series != nil && !ev.Series.LastObservedTime.IsZero() {
-		return t.Before(ev.Series.LastObservedTime.Time)
+func beforeLatestEvent(t time.Time, ev *v1.Event) bool {
+	eventTimes := []time.Time{
+		ev.FirstTimestamp.Time,
+		ev.LastTimestamp.Time,
+		ev.EventTime.Time,
 	}
 
-	return t.Before(ev.LastTimestamp.Time)
+	if ev.Series != nil {
+		eventTimes = append(eventTimes, ev.Series.LastObservedTime.Time)
+	}
+
+	latest := ev.CreationTimestamp.Time
+	for _, eventTime := range eventTimes {
+		if eventTime.After(latest) {
+			latest = eventTime
+		}
+	}
+
+	return t.Before(latest)
 }
 
 func updatedEventNb(oldEv, newEv *v1.Event) int32 {

--- a/internal/collector/event_test.go
+++ b/internal/collector/event_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2020 Red Hat, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBeforeLatestEvent(t *testing.T) {
+	now := time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)
+	older := now.Add(-time.Minute)
+	newer := now.Add(time.Minute)
+
+	newerSimpleEvent := &v1.Event{}
+	newerSimpleEvent.CreationTimestamp = metav1.NewTime(newer)
+
+	olderSimpleEvent := &v1.Event{}
+	olderSimpleEvent.CreationTimestamp = metav1.NewTime(older)
+
+	scenarios := []struct {
+		Desc     string
+		Event    *v1.Event
+		Expected bool
+	}{
+		{
+			Desc:     "api:newer",
+			Event:    newerSimpleEvent,
+			Expected: true,
+		},
+		{
+			Desc:     "api:older",
+			Event:    olderSimpleEvent,
+			Expected: false,
+		},
+		{
+			Desc: "core.EventRecorder:newer",
+			Event: &v1.Event{
+				FirstTimestamp: metav1.NewTime(older),
+				LastTimestamp:  metav1.NewTime(newer),
+			},
+			Expected: true,
+		},
+		{
+			Desc: "core.EventRecorder:older",
+			Event: &v1.Event{
+				FirstTimestamp: metav1.NewTime(older),
+				LastTimestamp:  metav1.NewTime(older),
+			},
+			Expected: false,
+		},
+		{
+			Desc: "events.EventRecorder:newer",
+			Event: &v1.Event{
+				EventTime: metav1.NewMicroTime(newer),
+			},
+			Expected: true,
+		},
+		{
+			Desc: "events.EventRecorder:older",
+			Event: &v1.Event{
+				EventTime: metav1.NewMicroTime(older),
+			},
+			Expected: false,
+		},
+		{
+			Desc: "events.EventRecorder:newer_serie",
+			Event: &v1.Event{
+				Series: &v1.EventSeries{LastObservedTime: metav1.NewMicroTime(newer)},
+			},
+			Expected: true,
+		},
+		{
+			Desc: "events.EventRecorder:older_serie",
+			Event: &v1.Event{
+				Series: &v1.EventSeries{LastObservedTime: metav1.NewMicroTime(older)},
+			},
+			Expected: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		scenario := scenario
+		t.Run(scenario.Desc, func(t *testing.T) {
+			t.Parallel()
+			result := beforeLatestEvent(now, scenario.Event)
+			if result != scenario.Expected {
+				t.Fatalf("expected %t", scenario.Expected)
+			}
+		})
+	}
+}
+
+func TestUpdatedEventNb(t *testing.T) {
+	scenarios := []struct {
+		Desc     string
+		OldEvent v1.Event
+		NewEvent v1.Event
+		Expected int32
+	}{
+		{
+			Desc:     "0_updated",
+			OldEvent: v1.Event{Count: 1},
+			NewEvent: v1.Event{Count: 1},
+			Expected: 0,
+		},
+		{
+			Desc:     "10_updated",
+			OldEvent: v1.Event{Count: 1},
+			NewEvent: v1.Event{Count: 11},
+			Expected: 10,
+		},
+		{
+			Desc:     "0_series_updated",
+			OldEvent: v1.Event{Series: &v1.EventSeries{Count: 1}},
+			NewEvent: v1.Event{Series: &v1.EventSeries{Count: 1}},
+			Expected: 0,
+		},
+		{
+			Desc:     "10_series_updated",
+			OldEvent: v1.Event{Series: &v1.EventSeries{Count: 1}},
+			NewEvent: v1.Event{Series: &v1.EventSeries{Count: 11}},
+			Expected: 10,
+		},
+		{
+			Desc:     "new_serie",
+			OldEvent: v1.Event{},
+			NewEvent: v1.Event{Series: &v1.EventSeries{Count: 1}},
+			Expected: 1,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		scenario := scenario
+		t.Run(scenario.Desc, func(t *testing.T) {
+			t.Parallel()
+			nbNew := updatedEventNb(&scenario.OldEvent, &scenario.NewEvent)
+			if nbNew != scenario.Expected {
+				t.Errorf("expected %d updated Events, got %d", scenario.Expected, nbNew)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In the case of a singleton Event generated by `k8s.io/client-go/tools/events` EventRecorder, the Event creation Timestamp is only set inside the EventTime field. Leaving both the Series and the LastTimestamp nil. Thus, we also need to check the EventTime before updating kube_events_total counter.