### PR TITLE
Add simple Event creation e2e test

### DIFF
--- a/test/e2e/event_test.go
+++ b/test/e2e/event_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2020 Red Hat, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"reflect"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEventCreation(t *testing.T) {
+	exporter := framework.CreateKubeEventsExporter(t)
+
+	event := &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		InvolvedObject: v1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: "default",
+		},
+		Count:  1,
+		Reason: "test",
+		Type:   v1.EventTypeNormal,
+	}
+	event = framework.CreateEvent(t, event, event.InvolvedObject.Namespace)
+	err := framework.WaitUntilEventReady(event.Namespace, event.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	families, err := exporter.GetEventMetricFamilies()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	eventsTotal, found := families["kube_events_total"]
+	if !found {
+		t.Fatal("kube_events_total metric not found")
+	}
+
+	expectedMetric := dto.Metric{
+		Label: []*dto.LabelPair{
+			{Name: stringPtr("involved_object_kind"), Value: &event.InvolvedObject.Kind},
+			{Name: stringPtr("involved_object_namespace"), Value: &event.InvolvedObject.Namespace},
+			{Name: stringPtr("reason"), Value: &event.Reason},
+			{Name: stringPtr("type"), Value: &event.Type},
+		},
+		Counter: &dto.Counter{Value: float64Ptr(1)},
+	}
+
+	for _, metric := range eventsTotal.Metric {
+		if reflect.DeepEqual(metric.Label, expectedMetric.Label) {
+			if !reflect.DeepEqual(metric.Counter, expectedMetric.Counter) {
+				t.Fatalf("kube_events_total value is %v instead of %v", metric.Counter.GetValue(), expectedMetric.Counter.GetValue())
+			}
+			return
+		}
+	}
+	t.Fatal("kube_events_total metric not found")
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}

--- a/test/framework/event.go
+++ b/test/framework/event.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 Red Hat, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// CreateEvent creates the given Event.
+func (f *Framework) CreateEvent(t *testing.T, event *v1.Event, ns string) *v1.Event {
+	event, err := f.KubeClient.CoreV1().Events(ns).Create(context.TODO(), event, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create event %s: %v", event.Name, err)
+	}
+
+	t.Cleanup(func() {
+		err := f.DeleteEvent(event.Namespace, event.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	return event
+}
+
+// DeleteEvent deletes the given Event.
+func (f *Framework) DeleteEvent(ns, name string) error {
+	err := f.KubeClient.CoreV1().Events(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "delete event %s", name)
+	}
+	return nil
+}
+
+// GetEvent gets the given Event.
+func (f *Framework) GetEvent(ns, name string) (*v1.Event, error) {
+	event, err := f.KubeClient.CoreV1().Events(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "get event %s", name)
+	}
+	return event, nil
+}
+
+// WaitUntilEventReady waits until given Event is ready.
+func (f *Framework) WaitUntilEventReady(ns, name string) error {
+	err := wait.Poll(time.Second, f.DefaultTimeout, func() (bool, error) {
+		_, err := f.GetEvent(ns, name)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "event %s not ready", name)
+	}
+
+	return nil
+}

--- a/test/framework/event.go
+++ b/test/framework/event.go
@@ -19,13 +19,10 @@ package framework
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // CreateEvent creates the given Event.
@@ -51,33 +48,5 @@ func (f *Framework) DeleteEvent(ns, name string) error {
 	if err != nil {
 		return errors.Wrapf(err, "delete event %s", name)
 	}
-	return nil
-}
-
-// GetEvent gets the given Event.
-func (f *Framework) GetEvent(ns, name string) (*v1.Event, error) {
-	event, err := f.KubeClient.CoreV1().Events(ns).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "get event %s", name)
-	}
-	return event, nil
-}
-
-// WaitUntilEventReady waits until given Event is ready.
-func (f *Framework) WaitUntilEventReady(ns, name string) error {
-	err := wait.Poll(time.Second, f.DefaultTimeout, func() (bool, error) {
-		_, err := f.GetEvent(ns, name)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-	if err != nil {
-		return errors.Wrapf(err, "event %s not ready", name)
-	}
-
 	return nil
 }


### PR DESCRIPTION
This PR adds a simple test verifying that when an Event gets created, the adequate kube_events_total metric is exposed by the exporter.

Depends on #43 #44 
Needs #37 for the test to succeed.

cc @rhobs/team-monitoring 