### PR TITLE
Fix namespace filter option naming

### DIFF
--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -67,7 +67,7 @@ func (o *Options) AddFlags() {
 	o.flags.StringVar(&o.ExporterHost, "exporter-host", "0.0.0.0", "Host to expose kube-events-exporter own metrics on.")
 	o.flags.IntVar(&o.ExporterPort, "exporter-port", 8081, "Port to expose kube-events-exporter own metrics on.")
 	o.flags.BoolVar(&o.Version, "version", false, "kube-events-exporter version information")
-	o.flags.StringArrayVar(&o.InvolvedObjectNamespaces, "involved_object_namespaces", []string{metav1.NamespaceAll}, "Events involved object namespace filter. Defaults to all namespaces.")
+	o.flags.StringArrayVar(&o.InvolvedObjectNamespaces, "involved-object-namespaces", []string{metav1.NamespaceAll}, "Events involved object namespace filter. Defaults to all namespaces.")
 }
 
 // Parse parses the flag definitions from the argument list.


### PR DESCRIPTION
After having a new look at it, it felt kind of awkward to have underscores in the option name.

cc @lilic 