### PR TITLE
Fix exporter polling mechanism in e2e tests

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"flag"
 	"log"
-	"net/http"
 	"os"
 	"testing"
 
@@ -50,26 +49,4 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(m.Run())
-}
-
-func TestKubeEventsExporterRunning(t *testing.T) {
-	exporter := framework.CreateKubeEventsExporter(t)
-
-	resp, err := http.Get(exporter.EventServerURL)
-	if err != nil {
-		t.Fatalf("event server not running %v", err)
-	}
-	err = resp.Body.Close()
-	if err != nil {
-		t.Log(err)
-	}
-
-	resp, err = http.Get(exporter.ExporterServerURL)
-	if err != nil {
-		t.Fatalf("exporter server not running %v", err)
-	}
-	err = resp.Body.Close()
-	if err != nil {
-		t.Log(err)
-	}
 }

--- a/test/framework/deployment.go
+++ b/test/framework/deployment.go
@@ -21,24 +21,12 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
-
-// GetDeployment gets the given deployment.
-func (f *Framework) GetDeployment(ns, name string) (*appsv1.Deployment, error) {
-	deployment, err := f.KubeClient.AppsV1().Deployments(ns).Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, errors.Wrapf(err, "get deployment %s", name)
-	}
-	return deployment, nil
-}
 
 // CreateDeployment creates the given deployment.
 func (f *Framework) CreateDeployment(t *testing.T, deployment *appsv1.Deployment, ns string) *appsv1.Deployment {
@@ -79,24 +67,5 @@ func (f *Framework) DeleteDeployment(ns, name string) error {
 	if err != nil {
 		return errors.Wrapf(err, "delete deployment %s", name)
 	}
-	return nil
-}
-
-// WaitUntilDeploymentReady waits until given deployment is ready.
-func (f *Framework) WaitUntilDeploymentReady(ns, name string) error {
-	err := wait.Poll(time.Second, f.DefaultTimeout, func() (bool, error) {
-		deployment, err := f.GetDeployment(ns, name)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		return deployment.Status.ReadyReplicas == *deployment.Spec.Replicas, nil
-	})
-	if err != nil {
-		return errors.Wrapf(err, "deployment %s pods are not ready", name)
-	}
-
 	return nil
 }


### PR DESCRIPTION
##### Update exporter polling mechanism in e2e tests
Poll /healthz exporter endpoint instead of deployment replica counts
to avoid Events being filtered out, and thus introducing flakes.

##### Remove exporter readiness e2e test
As we are now creating a new exporter before each test and checking for
its readiness, it is meaningless to have a test verifying something
that is already checked in all the other tests.

Fixes #51 

cc @rhobs/team-monitoring 