### PR TITLE
Add Event reason filtering

### DIFF
--- a/internal/collector/event.go
+++ b/internal/collector/event.go
@@ -59,9 +59,9 @@ func NewEventCollector(kubeClient kubernetes.Interface, opts *options.Options) *
 		lock:              sync.Mutex{},
 		informerFactories: factories,
 		filter: eventFilter{
-			creationTimestamp:           time.Now(),
-			apiGroups:                   opts.InvolvedObjectAPIGroups,
-			controllersReportingReasons: opts.ControllersReportingReasons,
+			creationTimestamp: time.Now(),
+			apiGroups:         opts.InvolvedObjectAPIGroups,
+			controllers:       opts.ReportingControllers,
 		},
 	}
 

--- a/internal/collector/event.go
+++ b/internal/collector/event.go
@@ -59,8 +59,9 @@ func NewEventCollector(kubeClient kubernetes.Interface, opts *options.Options) *
 		lock:              sync.Mutex{},
 		informerFactories: factories,
 		filter: eventFilter{
-			creationTimestamp: time.Now(),
-			apiGroups:         opts.InvolvedObjectAPIGroups,
+			creationTimestamp:           time.Now(),
+			apiGroups:                   opts.InvolvedObjectAPIGroups,
+			controllersReportingReasons: opts.ControllersReportingReasons,
 		},
 	}
 
@@ -154,7 +155,7 @@ func filterInvolvedObjectNs(list *metav1.ListOptions, ns string) {
 }
 
 func filterEventType(list *metav1.ListOptions, eventType string) {
-	if eventType != options.EventTypesAll {
+	if eventType != options.EventTypeAll {
 		list.FieldSelector += ",type=" + eventType
 	}
 }

--- a/internal/collector/filter.go
+++ b/internal/collector/filter.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	eventReasonMask = "Unknown"
+	eventReasonMask = "ReasonMaskedByExporter"
 )
 
 type eventFilter struct {

--- a/internal/collector/filter_test.go
+++ b/internal/collector/filter_test.go
@@ -180,7 +180,7 @@ func TestIncludedObjectAPIGroup(t *testing.T) {
 	}
 }
 
-func TestShouldMaskReason(t *testing.T) {
+func TestIncludedController(t *testing.T) {
 	testCases := []struct {
 		desc        string
 		controllers []string
@@ -189,33 +189,33 @@ func TestShouldMaskReason(t *testing.T) {
 	}{
 		{
 			desc:        "IncludedSource",
-			controllers: []string{"default-scheduler", "kubelet"},
+			controllers: []string{"default-scheduler", "kube-proxy", "kubelet"},
 			event:       &v1.Event{Source: v1.EventSource{Component: "kubelet"}},
-			expect:      false,
+			expect:      true,
 		},
 		{
 			desc:        "ExcludedSource",
-			controllers: []string{"kubelet"},
+			controllers: []string{"kube-proxy", "kubelet"},
 			event:       &v1.Event{Source: v1.EventSource{Component: "default-scheduler"}},
-			expect:      true,
-		},
-		{
-			desc:        "IncludedController",
-			controllers: []string{"kubelet", "default-scheduler"},
-			event:       &v1.Event{ReportingController: "kubelet"},
 			expect:      false,
 		},
 		{
-			desc:        "ExcludedController",
-			controllers: []string{"kubelet"},
-			event:       &v1.Event{ReportingController: "default-scheduler"},
+			desc:        "IncludedController",
+			controllers: []string{"default-scheduler", "kube-proxy", "kubelet"},
+			event:       &v1.Event{ReportingController: "kubelet"},
 			expect:      true,
+		},
+		{
+			desc:        "ExcludedController",
+			controllers: []string{"kube-proxy", "kubelet"},
+			event:       &v1.Event{ReportingController: "default-scheduler"},
+			expect:      false,
 		},
 		{
 			desc:        "IncludeAll",
 			controllers: []string{""},
 			event:       &v1.Event{Source: v1.EventSource{Component: "kubelet"}},
-			expect:      false,
+			expect:      true,
 		},
 	}
 
@@ -223,7 +223,7 @@ func TestShouldMaskReason(t *testing.T) {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
-			got := shouldMaskReason(tc.controllers, tc.event)
+			got := includedController(tc.event, tc.controllers)
 			if got != tc.expect {
 				t.Fatalf("expected %t, got %t", tc.expect, got)
 			}

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -84,7 +84,7 @@ func (o *Options) AddFlags() {
 	o.flags.IntVar(&o.ExporterPort, "exporter-port", 8081, "Port to expose kube-events-exporter own metrics on.")
 	o.flags.BoolVar(&o.Version, "version", false, "kube-events-exporter version information")
 
-	o.flags.StringArrayVar(&o.ControllersReportingReasons, "controllers-reporting-reasons", []string{ControllerReportingReasonAll}, "List of controllers allowed to report Event reasons. Filtered-out reasons will be replaced by Unknown. Defaults to all controllers.")
+	o.flags.StringArrayVar(&o.ControllersReportingReasons, "controllers-reporting-reasons", []string{ControllerReportingReasonAll}, "List of controllers allowed to report Event reasons. Filtered-out reasons will be replaced by ReasonMaskedByExporter. Defaults to all controllers.")
 	o.flags.StringArrayVar(&o.EventTypes, "event-types", []string{EventTypeAll}, "List of allowed Event types. Defaults to all types.")
 	o.flags.StringArrayVar(&o.InvolvedObjectAPIGroups, "involved-object-api-groups", []string{APIGroupAll}, "List of allowed Event involved object API groups. Defaults to all API groups.")
 	o.flags.StringArrayVar(&o.InvolvedObjectNamespaces, "involved-object-namespaces", []string{metav1.NamespaceAll}, "List of allowed Event involved object namespaces. Defaults to all namespaces.")

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -27,12 +27,16 @@ import (
 )
 
 const (
-	// EventTypesAll is the argument to specify to allow all Event types.
-	EventTypesAll = ""
+	// EventTypeAll is the argument to specify to allow all Event types.
+	EventTypeAll = ""
 
-	// APIGroupsAll is the argument to specify to allow objects from all API
+	// APIGroupAll is the argument to specify to allow objects from all API
 	// groups.
-	APIGroupsAll = ""
+	APIGroupAll = ""
+
+	// ControllerReportingReasonAll is the argument to specify to allow Event
+	// reasons reported by all controllers.
+	ControllerReportingReasonAll = ""
 )
 
 // Options are the configurable parameters for kube-events-exporter.
@@ -45,9 +49,10 @@ type Options struct {
 	ExporterPort int
 	Version      bool
 
-	EventTypes               []string
-	InvolvedObjectAPIGroups  []string
-	InvolvedObjectNamespaces []string
+	ControllersReportingReasons []string
+	EventTypes                  []string
+	InvolvedObjectAPIGroups     []string
+	InvolvedObjectNamespaces    []string
 
 	flags *pflag.FlagSet
 }
@@ -79,8 +84,9 @@ func (o *Options) AddFlags() {
 	o.flags.IntVar(&o.ExporterPort, "exporter-port", 8081, "Port to expose kube-events-exporter own metrics on.")
 	o.flags.BoolVar(&o.Version, "version", false, "kube-events-exporter version information")
 
-	o.flags.StringArrayVar(&o.EventTypes, "event-types", []string{EventTypesAll}, "List of allowed Event types. Defaults to all types.")
-	o.flags.StringArrayVar(&o.InvolvedObjectAPIGroups, "involved-object-api-groups", []string{APIGroupsAll}, "List of allowed Event involved object API groups. Defaults to all API groups.")
+	o.flags.StringArrayVar(&o.ControllersReportingReasons, "controllers-reporting-reasons", []string{ControllerReportingReasonAll}, "List of controllers allowed to report Event reasons. Filtered-out reasons will be replaced by Unknown. Defaults to all controllers.")
+	o.flags.StringArrayVar(&o.EventTypes, "event-types", []string{EventTypeAll}, "List of allowed Event types. Defaults to all types.")
+	o.flags.StringArrayVar(&o.InvolvedObjectAPIGroups, "involved-object-api-groups", []string{APIGroupAll}, "List of allowed Event involved object API groups. Defaults to all API groups.")
 	o.flags.StringArrayVar(&o.InvolvedObjectNamespaces, "involved-object-namespaces", []string{metav1.NamespaceAll}, "List of allowed Event involved object namespaces. Defaults to all namespaces.")
 }
 

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -34,9 +34,9 @@ const (
 	// groups.
 	APIGroupAll = ""
 
-	// ControllerReportingReasonAll is the argument to specify to allow Event
-	// reasons reported by all controllers.
-	ControllerReportingReasonAll = ""
+	// ReportingControllerAll is the argument to specify to allow Event
+	// reported by all controllers.
+	ReportingControllerAll = ""
 )
 
 // Options are the configurable parameters for kube-events-exporter.
@@ -49,10 +49,10 @@ type Options struct {
 	ExporterPort int
 	Version      bool
 
-	ControllersReportingReasons []string
-	EventTypes                  []string
-	InvolvedObjectAPIGroups     []string
-	InvolvedObjectNamespaces    []string
+	EventTypes               []string
+	InvolvedObjectAPIGroups  []string
+	InvolvedObjectNamespaces []string
+	ReportingControllers     []string
 
 	flags *pflag.FlagSet
 }
@@ -84,10 +84,10 @@ func (o *Options) AddFlags() {
 	o.flags.IntVar(&o.ExporterPort, "exporter-port", 8081, "Port to expose kube-events-exporter own metrics on.")
 	o.flags.BoolVar(&o.Version, "version", false, "kube-events-exporter version information")
 
-	o.flags.StringArrayVar(&o.ControllersReportingReasons, "controllers-reporting-reasons", []string{ControllerReportingReasonAll}, "List of controllers allowed to report Event reasons. Filtered-out reasons will be replaced by ReasonMaskedByExporter. Defaults to all controllers.")
 	o.flags.StringArrayVar(&o.EventTypes, "event-types", []string{EventTypeAll}, "List of allowed Event types. Defaults to all types.")
 	o.flags.StringArrayVar(&o.InvolvedObjectAPIGroups, "involved-object-api-groups", []string{APIGroupAll}, "List of allowed Event involved object API groups. Defaults to all API groups.")
 	o.flags.StringArrayVar(&o.InvolvedObjectNamespaces, "involved-object-namespaces", []string{metav1.NamespaceAll}, "List of allowed Event involved object namespaces. Defaults to all namespaces.")
+	o.flags.StringArrayVar(&o.ReportingControllers, "reporting-controllers", []string{ReportingControllerAll}, "List of controllers allowed to report Event. Defaults to all controllers.")
 }
 
 // Parse parses the flag definitions from the argument list.

--- a/test/framework/event.go
+++ b/test/framework/event.go
@@ -87,6 +87,9 @@ func NewBasicEvent() *v1.Event {
 			Kind:      "Pod",
 			Namespace: "default",
 		},
+		Source: v1.EventSource{
+			Component: "kubelet",
+		},
 		Count:  1,
 		Reason: "test",
 		Type:   v1.EventTypeNormal,


### PR DESCRIPTION
As any controller is able to report an unbound amount of custom Event reasons, we need to introduce a mechanism to filter reasons in order to avoid cardinality bursts.

To do so, this PR adds the `--controllers-reporting-reasons` flag which makes it possible to allow only some controllers to report reasons. For controllers that are not allowed to report reasons, metrics will still be exposed but their `reason` label will be set to `ReasonMaskedByExporter`.

/cc @rhobs/team-monitoring 