### PR TITLE
Add namespace and event type filters e2e tests

### DIFF
--- a/test/e2e/exporter_test.go
+++ b/test/e2e/exporter_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestExporterRequestsTotal(t *testing.T) {
-	exporter := framework.CreateKubeEventsExporter(t)
+	exporter := f.CreateKubeEventsExporter(t)
 	nbRequests := 10
 
 	for i := 0; i < nbRequests; i++ {

--- a/test/e2e/filter_test.go
+++ b/test/e2e/filter_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2020 Red Hat, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/rhobs/kube-events-exporter/test/framework"
+)
+
+func TestNamespaceFilter(t *testing.T) {
+	namespace := framework.NewBasicEvent().InvolvedObject.Namespace
+
+	testCases := []struct {
+		name      string
+		namespace string
+		assert    framework.AssertEventsTotalFunc
+	}{
+		{
+			name:      "Included",
+			namespace: namespace,
+			assert:    f.AssertEventsTotalPresent,
+		},
+		{
+			name:      "Excluded",
+			namespace: fmt.Sprintf("not-%s", namespace),
+			assert:    f.AssertEventsTotalAbsent,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			f := *f
+			f.ExporterArgs = []string{fmt.Sprintf("--involved-object-namespaces=%s", tc.namespace)}
+			exporter := f.CreateKubeEventsExporter(t)
+			event := f.CreateBasicEvent(t)
+			tc.assert(t, exporter, event, 1)
+		})
+	}
+}

--- a/test/e2e/filter_test.go
+++ b/test/e2e/filter_test.go
@@ -54,3 +54,35 @@ func TestNamespaceFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestEventTypeFilter(t *testing.T) {
+	eventType := framework.NewBasicEvent().Type
+
+	testCases := []struct {
+		name      string
+		eventType string
+		assert    framework.AssertEventsTotalFunc
+	}{
+		{
+			name:      "Included",
+			eventType: eventType,
+			assert:    f.AssertEventsTotalPresent,
+		},
+		{
+			name:      "Excluded",
+			eventType: fmt.Sprintf("not-%s", eventType),
+			assert:    f.AssertEventsTotalAbsent,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			f := *f
+			f.ExporterArgs = []string{fmt.Sprintf("--event-types=%s", tc.eventType)}
+			exporter := f.CreateKubeEventsExporter(t)
+			event := f.CreateBasicEvent(t)
+			tc.assert(t, exporter, event, 1)
+		})
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -22,11 +22,11 @@ import (
 	"os"
 	"testing"
 
-	exporterFramework "github.com/rhobs/kube-events-exporter/test/framework"
+	"github.com/rhobs/kube-events-exporter/test/framework"
 )
 
 var (
-	framework *exporterFramework.Framework
+	f *framework.Framework
 )
 
 func TestMain(m *testing.M) {
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	var err error
-	framework, err = exporterFramework.NewFramework(*kubeconfig, *exporterImage)
+	f, err = framework.NewFramework(*kubeconfig, *exporterImage)
 	if err != nil {
 		log.Fatalf("setup test framework: %v", err)
 	}

--- a/test/framework/assert.go
+++ b/test/framework/assert.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 Red Hat, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	eventsTotal = "kube_events_total"
+)
+
+// AssertEventsTotalFunc is a function that assert kube_events_total metrics.
+type AssertEventsTotalFunc func(t *testing.T, exporter *KubeEventsExporter, event *v1.Event, count float64)
+
+// AssertEventsTotalPresent asserts that the kube_events_total metric related
+// to the given event and count is present on the exporter.
+func (f *Framework) AssertEventsTotalPresent(t *testing.T, exporter *KubeEventsExporter, event *v1.Event, count float64) {
+	err := pollEventsTotalMetric(f, exporter, event, count)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AssertEventsTotalAbsent asserts that the kube_events_total metric related to
+// the given event and count is absent on the exporter.
+func (f *Framework) AssertEventsTotalAbsent(t *testing.T, exporter *KubeEventsExporter, event *v1.Event, count float64) {
+	err := pollEventsTotalMetric(f, exporter, event, count)
+	if err == nil {
+		t.Fatal("found unexpected kube_events_total metric")
+	}
+}
+
+func pollEventsTotalMetric(f *Framework, exporter *KubeEventsExporter, event *v1.Event, count float64) error {
+	metric := expectedEventsTotal(event, count)
+	return f.PollMetric(exporter.GetEventMetricFamilies, eventsTotal, metric)
+}
+
+func expectedEventsTotal(ev *v1.Event, count float64) *dto.Metric {
+	return &dto.Metric{
+		Label: []*dto.LabelPair{
+			{Name: stringPtr("involved_object_kind"), Value: &ev.InvolvedObject.Kind},
+			{Name: stringPtr("involved_object_namespace"), Value: &ev.InvolvedObject.Namespace},
+			{Name: stringPtr("reason"), Value: &ev.Reason},
+			{Name: stringPtr("type"), Value: &ev.Type},
+		},
+		Counter: &dto.Counter{Value: &count},
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/test/framework/event.go
+++ b/test/framework/event.go
@@ -50,8 +50,17 @@ func (f *Framework) CreateEvent(t *testing.T, event *v1.Event, ns string) *v1.Ev
 	return event
 }
 
+// CreateBasicEvent creates a basic Event.
+func (f *Framework) CreateBasicEvent(t *testing.T) *v1.Event {
+	event := NewBasicEvent()
+	return f.CreateEvent(t, event, event.InvolvedObject.Namespace)
+}
+
 // UpdateEvent updates the given Event.
 func (f *Framework) UpdateEvent(event *v1.Event, ns string) (*v1.Event, error) {
+	event.Count++
+	event.LastTimestamp = metav1.Now()
+
 	event, err := f.KubeClient.CoreV1().Events(ns).Update(context.TODO(), event, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "update event %s", event.Name)
@@ -66,6 +75,23 @@ func (f *Framework) DeleteEvent(ns, name string) error {
 		return errors.Wrapf(err, "delete event %s", name)
 	}
 	return nil
+}
+
+// NewBasicEvent constructs a basic Event for test purposes.
+func NewBasicEvent() *v1.Event {
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		InvolvedObject: v1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: "default",
+		},
+		Count:  1,
+		Reason: "test",
+		Type:   v1.EventTypeNormal,
+		Action: "action",
+	}
 }
 
 // NewRecordEventRecorder constructs a record.EventRecorder.

--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -30,6 +30,7 @@ type Framework struct {
 	KubeClient     kubernetes.Interface
 	DefaultTimeout time.Duration
 	ExporterImage  string
+	ExporterArgs   []string
 }
 
 // NewFramework returns a new framework.

--- a/test/framework/kube-events-exporter.go
+++ b/test/framework/kube-events-exporter.go
@@ -115,6 +115,10 @@ func (f *Framework) CreateKubeEventsExporter(t *testing.T) *KubeEventsExporter {
 		// Override kube-events-exporter image with the one specified.
 		deployment.Spec.Template.Spec.Containers[0].Image = f.ExporterImage
 	}
+	if len(f.ExporterArgs) != 0 {
+		// Override kube-events-exporter arguments with the one specified.
+		deployment.Spec.Template.Spec.Containers[0].Args = f.ExporterArgs
+	}
 	f.CreateDeployment(t, deployment, exporterNamespace)
 
 	exporter := &KubeEventsExporter{


### PR DESCRIPTION
This PR adds e2e tests for the exporter `--involved-object-namespaces` and `--event-types` flags.
As we were already creating an exporter for each test, these filters are tested by injecting the flags in the exporter deployment.
The tests were added in `test/e2e/filter_test.go`.

Aside from that, this PR contains the following e2e tests refactoring:
- We are now using a templated Event to avoid duplicating event creation code.
- We are now using an assertion on the events_total metric to avoid duplicating the metric polling lines.

/cc @rhobs/team-monitoring 