### PR TITLE
cmd: fix segv when closing listeners

### DIFF
--- a/cmd/kube-events-exporter/main.go
+++ b/cmd/kube-events-exporter/main.go
@@ -94,9 +94,11 @@ func listenAndServe(mux *http.ServeMux, host string, port int) (func() error, fu
 		return http.Serve(listener, mux)
 	}
 	cleanup := func(error) {
-		err := listener.Close()
-		if err != nil {
-			klog.Errorf("failed to close listener: %v", err)
+		if listener != nil {
+			err := listener.Close()
+			if err != nil {
+				klog.Errorf("failed to close listener: %v", err)
+			}
 		}
 	}
 	return serve, cleanup


### PR DESCRIPTION
If any of the servers listeners wasn't created properly we are closing
them right away without checking if they are nil or not. Thus, when one
of them was not created properly, a segfault occurs.

cc @rhobs/team-monitoring 