### PR TITLE
ci: remove branch filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ go: "1.14.x"
 services:
   - docker
 
-branches:
-  only:
-    - master
-    - /^v.*$/
-
 stages:
   - vendor
   - generate


### PR DESCRIPTION
A branch filter was required when the project was not upstream. As this
is not the case anymore, we don't need it. Also, this mechanism prevent
jobs for release branches to be triggered.