### PR TITLE
test/framework: increase default timeout

### DIFF
--- a/test/framework/framework.go
+++ b/test/framework/framework.go
@@ -47,7 +47,7 @@ func NewFramework(kubeconfig, exporterImage string) (*Framework, error) {
 
 	framework := &Framework{
 		KubeClient:     kubeClient,
-		DefaultTimeout: 5 * time.Second,
+		DefaultTimeout: 7 * time.Second,
 		ExporterImage:  exporterImage,
 	}
 


### PR DESCRIPTION
Investigate TestEventUpdate flake: https://travis-ci.org/github/rhobs/kube-events-exporter/jobs/717238929

The TestEventUpdate test was failing from time to time. However, I could
not reproduce this failure and thus not assert if the issue was only
affecting this test or not. Looking into the code, this seems to be a
timeout issue that occurs very rarely so I slightly increase the
framework default timeout from 5 to 7 seconds.