### PR TITLE
Secure metrics endpoints

### DIFF
--- a/examples/secure.jsonnet
+++ b/examples/secure.jsonnet
@@ -1,0 +1,85 @@
+local lib = (import 'kube-events-exporter/kube-events-exporter.libsonnet') + {
+  config+:: {
+    namespace:: 'default',
+    version:: std.extVar("VERSION"),
+    imageRepo:: std.extVar("IMAGE_REPO"),
+  },
+};
+
+local tlsCipherSuites = [
+  'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',
+  'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',
+  'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
+  'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
+  'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305',
+  'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
+];
+
+{
+  local kee = lib.kubeEventsExporter + 
+  ((import 'kube-rbac-proxy/container.libsonnet') {
+    config+:: {
+      kubeRbacProxy: {
+        image: 'quay.io/brancz/kube-rbac-proxy:v0.6.0',
+        name: 'kube-rbac-proxy-event',
+        securePortName: 'https-event',
+        securePort: 8443,
+        secureListenAddress: ':%d' % self.securePort,
+        upstream: 'http://127.0.0.1:8080/',
+        tlsCipherSuites: tlsCipherSuites
+      },
+    },
+  }).deploymentMixin +
+  ((import 'kube-rbac-proxy/container.libsonnet') {
+    config+:: {
+      kubeRbacProxy: {
+        image: 'quay.io/brancz/kube-rbac-proxy:v0.6.0',
+        name: 'kube-rbac-proxy-exporter',
+        securePortName: 'https-exporter',
+        securePort: 9443,
+        secureListenAddress: ':%d' % self.securePort,
+        upstream: 'http://127.0.0.1:8081/',
+        tlsCipherSuites: tlsCipherSuites
+      },
+    },
+  }).deploymentMixin +
+  {
+    service+: {
+      spec+: {
+        ports: [
+          {
+            name: port.name,
+            port: port.port,
+            targetPort: port.name,
+          }
+          for port in [
+            { name: 'https-event', port: 8443 },
+            { name: 'https-exporter', port: 9443 },
+          ]
+        ],
+      },
+    },
+    serviceMonitor+: {
+      spec+: {
+        endpoints: [
+          {
+            port: port,
+            scheme: 'https',
+            bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+            tlsConfig: {
+              insecureSkipVerify: true,
+            },
+          } 
+          for port in ['https-event', 'https-exporter']
+        ],
+      },
+    },
+  },
+
+  'kube-events-exporter-cluster-role-binding': kee.clusterRoleBinding,
+  'kube-events-exporter-cluster-role': kee.clusterRole,
+  'kube-events-exporter-deployment': kee.deployment,
+  'kube-events-exporter-service-account': kee.serviceAccount,
+  'kube-events-exporter-service': kee.service,
+  'kube-events-exporter-service-monitor': kee.serviceMonitor,
+}

--- a/examples/secure.jsonnet
+++ b/examples/secure.jsonnet
@@ -74,6 +74,20 @@ local tlsCipherSuites = [
         ],
       },
     },
+    clusterRole+: {
+      rules+: [
+        {
+          apiGroups: ['authentication.k8s.io'],
+          resources: ['tokenreviews'],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['authorization.k8s.io'],
+          resources: ['subjectaccessreviews'],
+          verbs: ['create'],
+        },
+      ],
+    },
   },
 
   'kube-events-exporter-cluster-role-binding': kee.clusterRoleBinding,

--- a/examples/secure/kube-events-exporter-cluster-role-binding.yaml
+++ b/examples/secure/kube-events-exporter-cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: events-exporter
+    app.kubernetes.io/name: kube-events-exporter
+    app.kubernetes.io/version: 0.1.0
+  name: kube-events-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-events-exporter
+subjects:
+- kind: ServiceAccount
+  name: kube-events-exporter
+  namespace: default

--- a/examples/secure/kube-events-exporter-cluster-role.yaml
+++ b/examples/secure/kube-events-exporter-cluster-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: events-exporter
+    app.kubernetes.io/name: kube-events-exporter
+    app.kubernetes.io/version: 0.1.0
+  name: kube-events-exporter
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+  - watch

--- a/examples/secure/kube-events-exporter-cluster-role.yaml
+++ b/examples/secure/kube-events-exporter-cluster-role.yaml
@@ -14,3 +14,15 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/examples/secure/kube-events-exporter-deployment.yaml
+++ b/examples/secure/kube-events-exporter-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: events-exporter
+    app.kubernetes.io/name: kube-events-exporter
+    app.kubernetes.io/version: 0.1.0
+  name: kube-events-exporter
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: events-exporter
+      app.kubernetes.io/name: kube-events-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: events-exporter
+        app.kubernetes.io/name: kube-events-exporter
+        app.kubernetes.io/version: 0.1.0
+    spec:
+      containers:
+      - args: []
+        image: quay.io/dgrisonnet/kube-events-exporter:v0.1.0
+        name: kube-events-exporter
+        ports:
+        - containerPort: 8080
+          name: event
+        - containerPort: 8081
+          name: exporter
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:8443
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --upstream=http://127.0.0.1:8080/
+        image: quay.io/brancz/kube-rbac-proxy:v0.6.0
+        name: kube-rbac-proxy-event
+        ports:
+        - containerPort: 8443
+          name: https-event
+        securityContext:
+          runAsUser: 65534
+      - args:
+        - --logtostderr
+        - --secure-listen-address=:9443
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --upstream=http://127.0.0.1:8081/
+        image: quay.io/brancz/kube-rbac-proxy:v0.6.0
+        name: kube-rbac-proxy-exporter
+        ports:
+        - containerPort: 9443
+          name: https-exporter
+        securityContext:
+          runAsUser: 65534
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: kube-events-exporter

--- a/examples/secure/kube-events-exporter-service-account.yaml
+++ b/examples/secure/kube-events-exporter-service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: events-exporter
+    app.kubernetes.io/name: kube-events-exporter
+    app.kubernetes.io/version: 0.1.0
+  name: kube-events-exporter
+  namespace: default

--- a/examples/secure/kube-events-exporter-service-monitor.yaml
+++ b/examples/secure/kube-events-exporter-service-monitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: events-exporter
+    app.kubernetes.io/name: kube-events-exporter
+    app.kubernetes.io/version: 0.1.0
+  name: kube-events-exporter
+  namespace: default
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    port: https-event
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    port: https-exporter
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: events-exporter
+      app.kubernetes.io/name: kube-events-exporter

--- a/examples/secure/kube-events-exporter-service.yaml
+++ b/examples/secure/kube-events-exporter-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: events-exporter
+    app.kubernetes.io/name: kube-events-exporter
+    app.kubernetes.io/version: 0.1.0
+  name: kube-events-exporter
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: https-event
+    port: 8443
+    targetPort: https-event
+  - name: https-exporter
+    port: 9443
+    targetPort: https-exporter
+  selector:
+    app.kubernetes.io/component: events-exporter
+    app.kubernetes.io/name: kube-events-exporter

--- a/scripts/generate/jsonnetfile.json
+++ b/scripts/generate/jsonnetfile.json
@@ -3,6 +3,15 @@
   "dependencies": [
     {
       "source": {
+        "git": {
+          "remote": "https://github.com/prometheus-operator/kube-prometheus",
+          "subdir": "jsonnet/kube-prometheus/kube-rbac-proxy"
+        }
+      },
+      "version": "master"
+    },
+    {
+      "source": {
         "local": {
           "directory": "../../jsonnet/kube-events-exporter"
         }

--- a/scripts/generate/jsonnetfile.lock.json
+++ b/scripts/generate/jsonnetfile.lock.json
@@ -14,6 +14,16 @@
     },
     {
       "source": {
+        "git": {
+          "remote": "https://github.com/prometheus-operator/kube-prometheus",
+          "subdir": "jsonnet/kube-prometheus/kube-rbac-proxy"
+        }
+      },
+      "version": "a6e6853f62cb83cec3902a516afce9923e6685b4",
+      "sum": "Kk2h8TedjhZrx9eokNSxMkipasxf8ZdkhVxwTop9TYU="
+    },
+    {
+      "source": {
         "local": {
           "directory": "../../jsonnet/kube-events-exporter"
         }


### PR DESCRIPTION
This PR adds an example configuration securing the metrics endpoints of the exporter with kube-rbac-proxy sidecars.

Fixes #33